### PR TITLE
adds partnerships resolves #170

### DIFF
--- a/packages/contracts/contracts/ArrayLib.sol
+++ b/packages/contracts/contracts/ArrayLib.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+//https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol
+library ArrayLib {
+  function contains(address[] memory arr, address item)
+    internal
+    pure
+    returns (bool)
+  {
+    for (uint256 j = 0; j < arr.length; j++) {
+      if (arr[j] == item) return true;
+    }
+    return false;
+  }
+}

--- a/packages/contracts/contracts/ISplicePriceStrategy.sol
+++ b/packages/contracts/contracts/ISplicePriceStrategy.sol
@@ -1,7 +1,7 @@
 // contracts/ISplicePriceStrategy.sol
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
-import './StyleSettings.sol';
+import './Structs.sol';
 import './SpliceStyleNFT.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 

--- a/packages/contracts/contracts/Splice.sol
+++ b/packages/contracts/contracts/Splice.sol
@@ -35,6 +35,8 @@ import '@openzeppelin/contracts-upgradeable/utils/escrow/EscrowUpgradeable.sol';
 import 'hardhat/console.sol';
 
 import './BytesLib.sol';
+import './ArrayLib.sol';
+import './Structs.sol';
 import './SpliceStyleNFT.sol';
 
 /// @title Splice is a protocol to mint NFTs out of origin NFTs
@@ -250,15 +252,44 @@ contract Splice is
     return styleNFT.quoteFee(style_token_id, nfts, origin_token_ids);
   }
 
-  function splitMintFee(uint256 amount, uint32 style_token_id) internal {
-    uint256 feeForArtist = ARTIST_SHARE * amount.div(100);
-    uint256 feeForPlatform = amount.sub(feeForArtist); //Splice takes a 15% cut
+  function splitWithPartners(
+    address[] memory partnership_collections,
+    IERC721[] memory origin_collections
+  ) internal pure returns (bool) {
+    for (uint256 i = 0; i < origin_collections.length; i++) {
+      if (
+        ArrayLib.contains(
+          partnership_collections,
+          address(origin_collections[i])
+        )
+      ) {
+        return true;
+      }
+    }
+  }
 
-    address beneficiaryArtist = styleNFT.ownerOf(style_token_id);
-    //https://medium.com/@ethdapp/using-the-openzeppelin-escrow-library-6384f22caa99
-    feesEscrow.deposit{ value: feeForArtist }(beneficiaryArtist);
+  //https://medium.com/@ethdapp/using-the-openzeppelin-escrow-library-6384f22caa99
+  function splitMintFee(
+    uint256 amount,
+    uint32 styleTokenId,
+    IERC721[] memory origin_collections
+  ) internal {
+    uint256 feeForArtist = ARTIST_SHARE * amount.div(100);
+    uint256 feeForPlatform = amount.sub(feeForArtist);
+
+    Partnership memory partnership = styleNFT.getPartnership(styleTokenId);
+    if (
+      partnership.collections.length > 0 && partnership.until > block.timestamp
+    ) {
+      if (splitWithPartners(partnership.collections, origin_collections)) {
+        uint256 feeForPartners = feeForPlatform.div(2);
+        feeForPlatform = feeForPartners;
+        feesEscrow.deposit{ value: feeForPartners }(partnership.beneficiary);
+      }
+    }
+
+    feesEscrow.deposit{ value: feeForArtist }(styleNFT.ownerOf(styleTokenId));
     feesEscrow.deposit{ value: feeForPlatform }(platformBeneficiary);
-    //todo: add a share to a beneficiary of the origin collection.
   }
 
   function claimShares(address payable beneficiary)
@@ -286,7 +317,7 @@ contract Splice is
     //CHECKS
 
     if (
-      !styleNFT.canBeMintedOnCollections(
+      !styleNFT.isMintable(
         style_token_id,
         origin_collections,
         origin_token_ids,
@@ -339,7 +370,7 @@ contract Splice is
     provenanceToTokenId[_provenanceHash] = token_id;
 
     //INTERACTIONS
-    splitMintFee(fee, style_token_id);
+    splitMintFee(fee, style_token_id, origin_collections);
     _safeMint(msg.sender, token_id);
 
     if (surplus > 0) {

--- a/packages/contracts/contracts/Splice.sol
+++ b/packages/contracts/contracts/Splice.sol
@@ -316,16 +316,14 @@ contract Splice is
   ) public payable whenNotPaused nonReentrant returns (uint64 token_id) {
     //CHECKS
 
-    if (
-      !styleNFT.isMintable(
+    require(
+      styleNFT.isMintable(
         style_token_id,
         origin_collections,
         origin_token_ids,
         msg.sender
       )
-    ) {
-      revert NotAllowedToMint('unknown');
-    }
+    );
 
     //todo if there's more than one mint request in one block the quoted fee might be lower
     //than what the artist expects, (when using a bonded price strategy)

--- a/packages/contracts/contracts/SplicePriceStrategyStatic.sol
+++ b/packages/contracts/contracts/SplicePriceStrategyStatic.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
-import './StyleSettings.sol';
+import './Structs.sol';
 import './ISplicePriceStrategy.sol';
 import './SpliceStyleNFT.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';

--- a/packages/contracts/contracts/SpliceStyleNFT.sol
+++ b/packages/contracts/contracts/SpliceStyleNFT.sol
@@ -247,7 +247,7 @@ contract SpliceStyleNFT is
     if (allowlists[style_token_id].numReserved < 1) {
       revert NotEnoughTokensToMatchReservation(style_token_id);
     }
-    // INTERACTIONS
+    // EFFECTS
     allowlists[style_token_id].numReserved -= 1;
     mintsAlreadyAllowed[style_token_id][requestor] =
       mintsAlreadyAllowed[style_token_id][requestor] +
@@ -277,7 +277,7 @@ contract SpliceStyleNFT is
       revert AllowlistDurationTooShort(_reservedUntil);
     }
 
-    //INTERACTION
+    //EFFECTS
     allowlists[style_token_id] = Allowlist({
       numReserved: _numReserved,
       merkleRoot: _merkleRoot,
@@ -359,6 +359,10 @@ contract SpliceStyleNFT is
     uint64 until,
     bool exclusive
   ) public onlyStyleMinter {
+    if (styleSettings[style_token_id].mintedOfStyle > 0) {
+      revert('cant add a partnership after minting started');
+    }
+
     _partnerships[style_token_id] = Partnership({
       collections: collections,
       beneficiary: beneficiary,

--- a/packages/contracts/contracts/Structs.sol
+++ b/packages/contracts/contracts/Structs.sol
@@ -11,6 +11,15 @@ struct Allowlist {
   bytes32 merkleRoot;
 }
 
+struct Partnership {
+  address[] collections;
+  address beneficiary;
+  uint64 until;
+  /// @notice exclusive partnerships mean that all style inputs must be covered by the partnership
+  /// @notice unexclusive partnerships require only 1 input to be covered
+  bool exclusive;
+}
+
 struct StyleSettings {
   //counting up
   uint32 mintedOfStyle;

--- a/packages/contracts/test/lib/helpers.ts
+++ b/packages/contracts/test/lib/helpers.ts
@@ -95,15 +95,20 @@ export function createMerkleProof(allowedAddresses: string[]): MerkleTree {
 
 export async function mintSplice(
   splice: Splice,
-  nftAddress: string,
-  originTokenId: number,
+  nftAddress: string | string[],
+  originTokenId: number | number[],
   styleTokenId: number
 ): Promise<BigNumber> {
-  const fee = splice.quote(styleTokenId, [nftAddress], [originTokenId]);
+  const nftAddresses = Array.isArray(nftAddress) ? nftAddress : [nftAddress];
+  const originTokenIds = Array.isArray(originTokenId)
+    ? originTokenId
+    : [originTokenId];
+
+  const fee = splice.quote(styleTokenId, nftAddresses, originTokenIds);
   const receipt = await (
     await splice.mint(
-      [nftAddress],
-      [originTokenId],
+      nftAddresses,
+      originTokenIds,
       styleTokenId,
       [],
       constants.HashZero,

--- a/packages/contracts/test/partnerships.test.ts
+++ b/packages/contracts/test/partnerships.test.ts
@@ -231,4 +231,43 @@ describe('Partnerships', function () {
       styleTokenId
     );
   });
+
+  it('cannot start a partnership once minting has started', async () => {
+    const collection = await deployTestnetNFT();
+    const nft = await mintTestnetNFT(collection, _user);
+
+    const styleTokenId = await mintStyle(styleNFT, priceStrategy.address, {
+      maxInputs: 1,
+      priceInEth: '1',
+      saleIsActive: true
+    });
+
+    const partnerBeneficiary = ethers.Wallet.createRandom();
+
+    await mintSplice(
+      splice.connect(_user),
+      collection.address,
+      nft,
+      styleTokenId
+    );
+
+    try {
+      await (
+        await styleNFT.addCollectionPartnership(
+          [collection.address],
+          styleTokenId,
+          partnerBeneficiary.address,
+          FOREVER,
+          true
+        )
+      ).wait();
+      expect.fail(
+        'a partnership mustnt be established after minting has started'
+      );
+    } catch (e: any) {
+      expect(e.message).contains(
+        'cant add a partnership after minting started'
+      );
+    }
+  });
 });

--- a/packages/contracts/test/partnerships.test.ts
+++ b/packages/contracts/test/partnerships.test.ts
@@ -1,0 +1,234 @@
+import { expect } from 'chai';
+import { Signer } from 'ethers';
+import { ethers, network } from 'hardhat';
+import {
+  Splice,
+  SplicePriceStrategyStatic,
+  SpliceStyleNFT,
+  SpliceStyleNFT__factory
+} from '../typechain';
+import {
+  deploySplice,
+  deployStaticPriceStrategy,
+  deployTestnetNFT
+} from './lib/deployContracts';
+import { mintSplice, mintStyle, mintTestnetNFT } from './lib/helpers';
+
+const FOREVER = new Date('2100-12-31 12:00:00').getTime() / 1000;
+
+describe('Partnerships', function () {
+  let splice: Splice;
+  let priceStrategy: SplicePriceStrategyStatic;
+  let styleNFT: SpliceStyleNFT;
+
+  let signers: Signer[];
+  let _owner: Signer;
+  let _user: Signer;
+  let _platformBeneficiary: Signer;
+  let _styleMinter: Signer;
+
+  let partnerStyleId: number;
+
+  before(async function () {
+    signers = await ethers.getSigners();
+    _owner = signers[0];
+    _user = signers[1];
+    _platformBeneficiary = signers[2];
+    _styleMinter = signers[19];
+  });
+
+  beforeEach(async function () {
+    splice = await deploySplice();
+    const styleNftAddress = await splice.styleNFT();
+    const _styleNFT = SpliceStyleNFT__factory.connect(styleNftAddress, _owner);
+    priceStrategy = await deployStaticPriceStrategy(styleNftAddress);
+
+    const styleMinterAddress = await _styleMinter.getAddress();
+    await _styleNFT.toggleStyleMinter(styleMinterAddress, true);
+    styleNFT = _styleNFT.connect(_styleMinter);
+
+    await splice.setPlatformBeneficiary(
+      await _platformBeneficiary.getAddress()
+    );
+
+    partnerStyleId = await mintStyle(styleNFT, priceStrategy.address, {
+      maxInputs: 1,
+      priceInEth: '1',
+      saleIsActive: true
+    });
+  });
+
+  it('active partnerships share mint fees with the partners', async function () {
+    const ONE_DAY_AND_A_BIT = 60 * 60 * 24 + 60;
+
+    const partnerNft = await deployTestnetNFT();
+    const expires = new Date().getTime() + ONE_DAY_AND_A_BIT + 1;
+    const partnerBeneficiary = ethers.Wallet.createRandom();
+
+    await (
+      await styleNFT.addCollectionPartnership(
+        [partnerNft.address],
+        partnerStyleId,
+        partnerBeneficiary.address,
+        expires,
+        false
+      )
+    ).wait();
+
+    const nft = await mintTestnetNFT(partnerNft, _user);
+    await mintSplice(
+      splice.connect(_user),
+      partnerNft.address,
+      nft,
+      partnerStyleId
+    );
+    const balStyleOwner = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(await _styleMinter.getAddress())
+    );
+    const balPlatform = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(await _platformBeneficiary.getAddress())
+    );
+    const balPartner = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(partnerBeneficiary.address)
+    );
+
+    expect(balStyleOwner).to.be.equal('0.85');
+    expect(balPlatform).to.be.equal('0.075');
+    expect(balPartner).to.be.equal('0.075');
+
+    //since this is a nonexclusive partnership, other origins are allowed can mint
+    const someCollection = await deployTestnetNFT();
+    const someNft = await mintTestnetNFT(someCollection, _user);
+    await mintSplice(
+      splice.connect(_user),
+      someCollection.address,
+      someNft,
+      partnerStyleId
+    );
+    const balStyleOwner2 = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(await _styleMinter.getAddress())
+    );
+    const balPlatform2 = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(await _platformBeneficiary.getAddress())
+    );
+    const balPartner2 = ethers.utils.formatEther(
+      await splice.escrowedBalanceOf(partnerBeneficiary.address)
+    );
+
+    expect(balStyleOwner2).to.be.equal('1.7');
+    expect(balPlatform2).to.be.equal('0.225');
+    expect(balPartner2).to.be.equal('0.075');
+  });
+
+  it('can be constrained to exclusive, unlimited partnerships', async function () {
+    const collection1 = await deployTestnetNFT();
+    const collection2 = await deployTestnetNFT();
+    const partnerBeneficiary = ethers.Wallet.createRandom();
+
+    const styleTokenId = await mintStyle(styleNFT, priceStrategy.address, {
+      maxInputs: 2,
+      priceInEth: '1',
+      saleIsActive: true
+    });
+
+    await (
+      await styleNFT.addCollectionPartnership(
+        [collection1.address, collection2.address],
+        styleTokenId,
+        partnerBeneficiary.address,
+        FOREVER,
+        true
+      )
+    ).wait();
+
+    const token1 = await mintTestnetNFT(collection1, _user);
+    const token2 = await mintTestnetNFT(collection2, _user);
+
+    await mintSplice(
+      splice.connect(_user),
+      collection1.address,
+      token1,
+      styleTokenId
+    );
+
+    await mintSplice(
+      splice.connect(_user),
+      [collection1.address, collection2.address],
+      [token1, token2],
+      styleTokenId
+    );
+  });
+
+  it('cannot mint from other origins on an exclusive collection', async () => {
+    const ONE_DAY_AND_A_BIT = 60 * 60 * 24 + 60;
+    const collection1 = await deployTestnetNFT();
+    const collection2 = await deployTestnetNFT();
+    const anotherNft = await deployTestnetNFT();
+
+    const goodToken = await mintTestnetNFT(collection1, _user);
+    const badToken = await mintTestnetNFT(anotherNft, _user);
+
+    const styleTokenId = await mintStyle(styleNFT, priceStrategy.address, {
+      maxInputs: 2,
+      priceInEth: '1',
+      saleIsActive: true
+    });
+    const partnerBeneficiary = ethers.Wallet.createRandom();
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber()
+    );
+    const expires = block.timestamp + ONE_DAY_AND_A_BIT;
+
+    await (
+      await styleNFT.addCollectionPartnership(
+        [collection1.address, collection2.address],
+        styleTokenId,
+        partnerBeneficiary.address,
+        expires,
+        true
+      )
+    ).wait();
+
+    try {
+      await mintSplice(
+        splice.connect(_user),
+        anotherNft.address,
+        badToken,
+        styleTokenId
+      );
+
+      expect.fail('should throw on constrained collection');
+    } catch (e: any) {
+      expect(e.message).to.contain(
+        'collection not part of exclusive partnership'
+      );
+    }
+
+    try {
+      await mintSplice(
+        splice.connect(_user),
+        [collection1.address, anotherNft.address],
+        [goodToken, badToken],
+        styleTokenId
+      );
+
+      expect.fail('should not allow exclusive partnerships to mix with others');
+    } catch (e: any) {
+      expect(e.message).to.contain(
+        'collection not part of exclusive partnership'
+      );
+    }
+
+    //partnership expires...
+
+    await network.provider.send('evm_increaseTime', [ONE_DAY_AND_A_BIT + 3600]);
+    await network.provider.send('evm_mine');
+
+    await mintSplice(
+      splice.connect(_user),
+      [collection1.address, anotherNft.address],
+      [goodToken, badToken],
+      styleTokenId
+    );
+  });
+});

--- a/packages/contracts/test/royalties.test.ts
+++ b/packages/contracts/test/royalties.test.ts
@@ -60,6 +60,7 @@ describe('Royalties', function () {
   });
 
   it('signals royalties', async function () {
+    await splice.updateRoyalties(5);
     const artistAddress = await _artist.getAddress();
 
     const _nft = testNft.connect(_seller);
@@ -72,9 +73,12 @@ describe('Royalties', function () {
       nftTokenId,
       1
     );
+
     const salePrice = ethers.utils.parseEther('1');
     const royaltyInfo = await splice.royaltyInfo(spliceTokenId, salePrice);
-    expect(ethers.utils.formatUnits(royaltyInfo.royaltyAmount)).to.equal('0.1');
+    expect(ethers.utils.formatUnits(royaltyInfo.royaltyAmount)).to.equal(
+      '0.05'
+    );
 
     const royaltyReceiver = royaltyInfo.receiver;
     expect(royaltyReceiver).to.equal(artistAddress);
@@ -95,7 +99,7 @@ describe('Royalties', function () {
     expect(royaltyInfo.receiver).to.equal(styleBuyerAddress);
   });
 
-  it('cannot increase royalties higher than 10%', async () => {
+  it('cannot set royalties higher than 10%', async () => {
     const _splice = splice.connect(_owner);
     try {
       await _splice.updateRoyalties(11);

--- a/packages/contracts/test/royalties.test.ts
+++ b/packages/contracts/test/royalties.test.ts
@@ -15,8 +15,6 @@ import {
 } from './lib/deployContracts';
 import { mintSplice, mintStyle, mintTestnetNFT } from './lib/helpers';
 
-const ONE_DAY_AND_A_BIT = 60 * 60 * 24 + 60;
-
 describe('Royalties', function () {
   let testNft: TestnetNFT;
   let splice: Splice;

--- a/packages/contracts/test/shares.test.ts
+++ b/packages/contracts/test/shares.test.ts
@@ -26,6 +26,8 @@ describe('Fee Splitting', function () {
   let _owner: Signer;
   let _user: Signer;
   let _platformBeneficiary: Signer;
+  let _anotherArtist: Signer;
+  let _partnerBeneficiary: Signer;
   let _styleMinter: Signer;
   let _seller: Signer;
   let _artist: Signer;
@@ -35,6 +37,8 @@ describe('Fee Splitting', function () {
     _owner = signers[0];
     _user = signers[1];
     _platformBeneficiary = signers[2];
+    _anotherArtist = signers[15];
+    _partnerBeneficiary = signers[16];
     _styleMinter = signers[17];
     _seller = signers[18];
     _artist = signers[19];
@@ -124,10 +128,8 @@ describe('Fee Splitting', function () {
   });
 
   it('reallocates funds to new owners of a style token', async function () {
-    const anotherArtist = signers[15];
-
     const _artistAddress = await _artist.getAddress();
-    const _anotherArtistAddress = await anotherArtist.getAddress();
+    const _anotherArtistAddress = await _anotherArtist.getAddress();
 
     const oldArtistShares = await splice.escrowedBalanceOf(_artistAddress);
 

--- a/packages/contracts/test/shares.test.ts
+++ b/packages/contracts/test/shares.test.ts
@@ -1,0 +1,246 @@
+import { expect } from 'chai';
+import { Signer } from 'ethers';
+import { ethers } from 'hardhat';
+import {
+  ChainWallet__factory,
+  Splice,
+  SplicePriceStrategyStatic,
+  SpliceStyleNFT,
+  SpliceStyleNFT__factory,
+  TestnetNFT
+} from '../typechain';
+import {
+  deploySplice,
+  deployStaticPriceStrategy,
+  deployTestnetNFT
+} from './lib/deployContracts';
+import { mintSplice, mintStyle, mintTestnetNFT } from './lib/helpers';
+
+describe('Fee Splitting', function () {
+  let testNft: TestnetNFT;
+  let splice: Splice;
+  let priceStrategy: SplicePriceStrategyStatic;
+  let styleNFT: SpliceStyleNFT;
+
+  let signers: Signer[];
+  let _owner: Signer;
+  let _user: Signer;
+  let _platformBeneficiary: Signer;
+  let _styleMinter: Signer;
+  let _seller: Signer;
+  let _artist: Signer;
+
+  beforeEach(async function () {
+    signers = await ethers.getSigners();
+    _owner = signers[0];
+    _user = signers[1];
+    _platformBeneficiary = signers[2];
+    _styleMinter = signers[17];
+    _seller = signers[18];
+    _artist = signers[19];
+  });
+
+  it('deploys nft & splice & mints a style', async function () {
+    splice = await deploySplice();
+    testNft = await deployTestnetNFT();
+    const styleNftAddress = await splice.styleNFT();
+    const _styleNFT = SpliceStyleNFT__factory.connect(styleNftAddress, _owner);
+
+    priceStrategy = await deployStaticPriceStrategy(styleNftAddress);
+
+    const styleMinterAddress = await _styleMinter.getAddress();
+    await _styleNFT.toggleStyleMinter(styleMinterAddress, true);
+    styleNFT = _styleNFT.connect(_styleMinter);
+
+    const styleId = await mintStyle(styleNFT, priceStrategy.address, {
+      priceInEth: '0.1',
+      saleIsActive: true,
+      maxInputs: 1
+    });
+    const artistAddress = await _artist.getAddress();
+    await styleNFT.transferFrom(styleMinterAddress, artistAddress, styleId);
+
+    expect((await styleNFT.balanceOf(artistAddress)).toNumber()).to.equal(1);
+    expect(await styleNFT.ownerOf(1)).to.equal(artistAddress);
+    await splice.setPlatformBeneficiary(
+      await _platformBeneficiary.getAddress()
+    );
+  });
+
+  it('withdraws shared funds from escrow', async function () {
+    const artistAddress = await _artist.getAddress();
+    const benefAddress = await _platformBeneficiary.getAddress();
+
+    const origin = await mintTestnetNFT(testNft, _user);
+    await mintSplice(splice.connect(_user), testNft.address, origin, 1);
+
+    const artistCollectedFees = await splice.escrowedBalanceOf(artistAddress);
+
+    const artistEth = ethers.utils.formatUnits(artistCollectedFees, 'ether');
+    const expected = 0.1 * 0.85; //1 mint for 0.1, 1 mint for 0.2 times 85% share
+    expect(expected.toString()).to.equal(artistEth);
+
+    const curBalance = await _artist.getBalance();
+    await (await splice.connect(_artist).claimShares(artistAddress)).wait();
+    const newBalance = await _artist.getBalance();
+
+    const diff = parseFloat(
+      ethers.utils.formatUnits(newBalance.sub(curBalance), 'ether')
+    );
+    expect(expected - diff).to.be.lessThan(0.001); //gas fees ;)
+
+    const benefCurBalance = await _platformBeneficiary.getBalance();
+    await (await splice.claimShares(benefAddress)).wait();
+    const benefNewBalance = await _platformBeneficiary.getBalance();
+    const benefDiff = parseFloat(
+      ethers.utils.formatUnits(benefNewBalance.sub(benefCurBalance), 'ether')
+    );
+    const benefExpected = 0.1 * 0.15;
+    expect(benefExpected - benefDiff).to.be.lessThan(0.001);
+  });
+
+  it('can change the platform beneficiary', async function () {
+    const signer13 = await signers[13].getAddress();
+    expect((await splice.escrowedBalanceOf(signer13)).isZero()).to.be.true;
+
+    try {
+      await splice.setPlatformBeneficiary(ethers.constants.AddressZero);
+      expect.fail('the platform beneficiary mustnt be zero');
+    } catch (e: any) {
+      expect(e.message).to.contain('must be a real address');
+    }
+
+    await splice.setPlatformBeneficiary(signer13);
+
+    const nftTokenId = await mintTestnetNFT(testNft, _user);
+
+    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 1);
+
+    const beneficiaryExpected = 0.1 * 0.15;
+    const beneficiaryShares = await splice.escrowedBalanceOf(signer13);
+    expect(ethers.utils.formatUnits(beneficiaryShares, 'ether')).to.be.equal(
+      beneficiaryExpected.toString()
+    );
+  });
+
+  it('reallocates funds to new owners of a style token', async function () {
+    const anotherArtist = signers[15];
+
+    const _artistAddress = await _artist.getAddress();
+    const _anotherArtistAddress = await anotherArtist.getAddress();
+
+    const oldArtistShares = await splice.escrowedBalanceOf(_artistAddress);
+
+    await (
+      await styleNFT
+        .connect(_artist)
+        .transferFrom(_artistAddress, _anotherArtistAddress, 1)
+    ).wait();
+
+    expect(await styleNFT.ownerOf(1)).to.be.equal(_anotherArtistAddress);
+
+    const nftTokenId = await mintTestnetNFT(testNft, _user);
+    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 1);
+
+    expect(await splice.escrowedBalanceOf(_artistAddress)).to.equal(
+      oldArtistShares
+    );
+
+    const anotherArtistShares = await splice.escrowedBalanceOf(
+      _anotherArtistAddress
+    );
+    const expected = 0.1 * 0.85;
+    expect(ethers.utils.formatUnits(anotherArtistShares, 'ether')).to.be.equal(
+      expected.toString()
+    );
+
+    //note: anybody may invoke the claimShares method on behalf of anyone else.
+    await splice.claimShares(_anotherArtistAddress);
+    expect(
+      await (await splice.escrowedBalanceOf(_anotherArtistAddress)).isZero()
+    ).to.be.true;
+  });
+
+  it('can update the artist share rate', async function () {
+    await splice.updateArtistShare(90);
+    const anotherArtist = signers[15];
+    const _anotherArtistAddress = await anotherArtist.getAddress();
+
+    const nftTokenId = await mintTestnetNFT(testNft, _user);
+
+    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 1);
+
+    const anotherArtistShares = await splice.escrowedBalanceOf(
+      _anotherArtistAddress
+    );
+    const expected = (0.1 * 0.9).toFixed(2);
+    expect(ethers.utils.formatUnits(anotherArtistShares, 'ether')).to.be.equal(
+      expected
+    );
+    await splice.claimShares(_anotherArtistAddress);
+    expect(
+      (await splice.escrowedBalanceOf(_anotherArtistAddress)).toNumber()
+    ).to.equal(0);
+
+    await (
+      await styleNFT
+        .connect(anotherArtist)
+        .transferFrom(_anotherArtistAddress, await _artist.getAddress(), 1)
+    ).wait();
+  });
+
+  it('can not withdraw from escrow when paused', async function () {
+    await splice.pause();
+
+    try {
+      await (
+        await splice.claimShares(await _platformBeneficiary.getAddress())
+      ).wait();
+      expect.fail('it shouldnt be possible to withdraw shares when paused');
+    } catch (e: any) {
+      expect(e.message).to.contain('Pausable: paused');
+    } finally {
+      await splice.unpause();
+    }
+  });
+
+  it('signals 10% royalties to the style nft owner', async function () {
+    const artistAddress = await _artist.getAddress();
+
+    const nftTokenId = await mintTestnetNFT(testNft.connect(_seller), _seller);
+    const spliceTokenId = await mintSplice(
+      splice.connect(_seller),
+      testNft.address,
+      nftTokenId,
+      1
+    );
+    const salePrice = ethers.utils.parseEther('1');
+    const royaltyInfo = await splice.royaltyInfo(spliceTokenId, salePrice);
+    expect(ethers.utils.formatUnits(royaltyInfo.royaltyAmount)).to.equal('0.1');
+
+    const royaltyReceiver = royaltyInfo.receiver;
+    expect(royaltyReceiver).to.equal(artistAddress);
+  });
+
+  it('the platform beneficiary can be a payable contract', async function () {
+    const ChainWallet = (await ethers.getContractFactory(
+      'ChainWallet'
+    )) as ChainWallet__factory;
+    const wallet = await ChainWallet.deploy();
+
+    splice.setPlatformBeneficiary(wallet.address);
+
+    const nft = await mintTestnetNFT(testNft, _user);
+    await mintSplice(splice.connect(_user), testNft.address, nft, 1);
+
+    const walletShare = await splice.escrowedBalanceOf(wallet.address);
+    expect(ethers.utils.formatUnits(walletShare, 'ether')).to.be.equal('0.01');
+
+    await wallet.withdrawShares(splice.address);
+
+    const walletBalance = await wallet.provider.getBalance(wallet.address);
+    expect(ethers.utils.formatUnits(walletBalance, 'ether')).to.be.equal(
+      '0.01'
+    );
+  });
+});

--- a/packages/contracts/test/splice.test.ts
+++ b/packages/contracts/test/splice.test.ts
@@ -311,7 +311,8 @@ describe('Splice', function () {
 
     const _styleNFT = styleNFT.connect(_styleMinter);
     const styleTokenId = await mintStyle(_styleNFT, priceStrategy.address, {
-      saleIsActive: true
+      saleIsActive: true,
+      maxInputs: 2
     });
     await _styleNFT.restrictToCollections(styleTokenId, [
       anotherNFT1.address,
@@ -334,8 +335,8 @@ describe('Splice', function () {
     expect(
       await _styleNFT.canBeMintedOnCollections(
         styleTokenId,
-        [anotherNFT2.address],
-        [testnetToken2],
+        [anotherNFT1.address, anotherNFT2.address],
+        [testnetToken1, testnetToken2],
         _userAddress
       )
     ).to.be.true;
@@ -362,8 +363,8 @@ describe('Splice', function () {
     //test that the constraints implicitly hold
     await (
       await _splice.mint(
-        [anotherNFT1.address],
-        [testnetToken1],
+        [anotherNFT1.address, anotherNFT2.address],
+        [testnetToken1, testnetToken2],
         styleTokenId,
         [],
         ethers.constants.HashZero,

--- a/packages/contracts/test/splice.test.ts
+++ b/packages/contracts/test/splice.test.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { BigNumber, Event, Signer } from 'ethers';
 import { ethers } from 'hardhat';
 import {
-  ChainWallet__factory,
   GLDToken__factory,
   IERC165__factory,
   IERC2981Upgradeable__factory,
@@ -35,11 +34,11 @@ describe('Splice', function () {
   let signers: Signer[];
   let _styleMinter: Signer;
   let _user: Signer;
-  let _owner: Signer;
+  let _platformBeneficiary: Signer;
 
   beforeEach(async function () {
     signers = await ethers.getSigners();
-    _owner = signers[0];
+    _platformBeneficiary = signers[1];
     _styleMinter = signers[18];
     _user = signers[19];
   });
@@ -57,6 +56,10 @@ describe('Splice', function () {
 
     const _styleNft = styleNFT.connect(_styleMinter);
     await mintStyle(_styleNft, priceStrategy.address, { saleIsActive: true });
+
+    await splice.setPlatformBeneficiary(
+      await _platformBeneficiary.getAddress()
+    );
   });
   it('gets an nft on the test collection', async function () {
     const nftTokenId = await mintTestnetNFT(testNft, _user);
@@ -269,123 +272,6 @@ describe('Splice', function () {
     expect(inputData.origin_token_ids[0]).to.equal(1);
   });
 
-  it('withdraws shared funds from escrow', async function () {
-    const styleMinterAddress = await _styleMinter.getAddress();
-    const ownerAddress = await _owner.getAddress();
-    const curatorCollectedFees = await splice.escrowedBalanceOf(
-      styleMinterAddress
-    );
-    const curatorEth = ethers.utils.formatUnits(curatorCollectedFees, 'ether');
-    const expected = (0.1 + 0.2) * 0.85; //1 mint for 0.1, 1 mint for 0.2 times 85% share
-    expect(expected.toString()).to.equal(curatorEth);
-
-    const curBalance = await _styleMinter.getBalance();
-    const _splice = splice.connect(_styleMinter);
-    await (await _splice.claimShares(styleMinterAddress)).wait();
-    const newBalance = await _styleMinter.getBalance();
-    const diff = parseFloat(
-      ethers.utils.formatUnits(newBalance.sub(curBalance), 'ether')
-    );
-    expect(expected - diff).to.be.lessThan(0.001); //gas fees ;)
-
-    const ownerCurBalance = await _owner.getBalance();
-    await (await splice.claimShares(ownerAddress)).wait();
-    const ownerNewBalance = await _owner.getBalance();
-    const ownerDiff = parseFloat(
-      ethers.utils.formatUnits(ownerNewBalance.sub(ownerCurBalance), 'ether')
-    );
-    const ownerExpected = (0.1 + 0.2) * 0.15;
-    expect(ownerExpected - ownerDiff).to.be.lessThan(0.001);
-  });
-
-  it('can change the platform beneficiary', async function () {
-    const signer13 = await signers[13].getAddress();
-    expect((await splice.escrowedBalanceOf(signer13)).isZero()).to.be.true;
-
-    try {
-      await splice.setPlatformBeneficiary(ethers.constants.AddressZero);
-      expect.fail('the platform beneficiary mustnt be zero');
-    } catch (e: any) {
-      expect(e.message).to.contain('must be a real address');
-    }
-
-    await splice.setPlatformBeneficiary(signer13);
-
-    const nftTokenId = await mintTestnetNFT(testNft, _user);
-    expect(nftTokenId).to.equal(2);
-
-    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 2);
-
-    const beneficiaryExpected = 0.2 * 0.15;
-    const beneficiaryShares = await splice.escrowedBalanceOf(signer13);
-    expect(ethers.utils.formatUnits(beneficiaryShares, 'ether')).to.be.equal(
-      beneficiaryExpected.toString()
-    );
-  });
-
-  it('reallocates funds to new owners of the style token', async function () {
-    const _styleNFT = styleNFT.connect(_styleMinter);
-    const anotherCurator = signers[15];
-    const _styleMinterAddress = await _styleMinter.getAddress();
-    const _anotherstyleMinterAddress = await anotherCurator.getAddress();
-    const oldCuratorShares = await splice.escrowedBalanceOf(
-      _styleMinterAddress
-    );
-
-    await (
-      await _styleNFT.transferFrom(
-        await _styleMinter.getAddress(),
-        _anotherstyleMinterAddress,
-        2
-      )
-    ).wait();
-
-    expect(await _styleNFT.ownerOf(2)).to.be.equal(_anotherstyleMinterAddress);
-
-    const nftTokenId = await mintTestnetNFT(testNft, _user);
-    expect(nftTokenId).to.equal(3);
-
-    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 2);
-
-    expect(await splice.escrowedBalanceOf(_styleMinterAddress)).to.equal(
-      oldCuratorShares
-    );
-
-    const anotherCuratorShares = await splice.escrowedBalanceOf(
-      _anotherstyleMinterAddress
-    );
-    const expected = 0.2 * 0.85;
-    expect(ethers.utils.formatUnits(anotherCuratorShares, 'ether')).to.be.equal(
-      expected.toString()
-    );
-    await splice
-      .connect(anotherCurator)
-      .claimShares(_anotherstyleMinterAddress);
-    expect(
-      await (
-        await splice.escrowedBalanceOf(_anotherstyleMinterAddress)
-      ).isZero()
-    ).to.be.true;
-  });
-
-  it('can update the artist share rate', async function () {
-    await splice.updateArtistShare(90);
-    const anotherCurator = signers[15];
-    const _anotherstyleMinterAddress = await anotherCurator.getAddress();
-
-    const nftTokenId = await mintTestnetNFT(testNft, _user);
-    expect(nftTokenId).to.equal(4);
-    await mintSplice(splice.connect(_user), testNft.address, nftTokenId, 2);
-
-    const anotherCuratorShares = await splice.escrowedBalanceOf(
-      _anotherstyleMinterAddress
-    );
-    const expected = (0.2 * 0.9).toFixed(2);
-    expect(ethers.utils.formatUnits(anotherCuratorShares, 'ether')).to.be.equal(
-      expected
-    );
-  });
-
   it('disallows writing on or replacing the style nft', async function () {
     try {
       await styleNFT.incrementMintedPerStyle(2);
@@ -412,19 +298,6 @@ describe('Splice', function () {
     try {
       await mintSplice(_splice, testNft.address, 2, 2);
       expect.fail('minting shouldnt be possible when paused');
-    } catch (e: any) {
-      expect(e.message).to.contain('Pausable: paused');
-    } finally {
-      await splice.unpause();
-    }
-  });
-
-  it('can not withdraw from escrow when paused', async function () {
-    await splice.pause();
-    const _ownerAddress = await _owner.getAddress();
-    try {
-      await (await splice.claimShares(_ownerAddress)).wait();
-      expect.fail('it shouldnt be possible to withdraw shares when paused');
     } catch (e: any) {
       expect(e.message).to.contain('Pausable: paused');
     } finally {
@@ -645,7 +518,7 @@ describe('Splice', function () {
     }
   });
 
-  it('cant be minted beyond limits', async function () {
+  it('cannot be minted beyond limits', async function () {
     const cappedStyleId = await mintStyle(
       styleNFT.connect(_styleMinter),
       priceStrategy.address,
@@ -688,7 +561,7 @@ describe('Splice', function () {
     expect((await erc20.balanceOf(splice.address)).toNumber()).to.equal(1000);
 
     const beneficiary = await splice.platformBeneficiary();
-    expect((await erc20.balanceOf(beneficiary)).isZero()).to.be.true;
+    expect((await erc20.balanceOf(beneficiary)).toNumber()).to.equal(0);
     await splice.withdrawERC20(erc20.address);
 
     expect((await erc20.balanceOf(beneficiary)).toNumber()).to.equal(1000);
@@ -741,29 +614,6 @@ describe('Splice', function () {
         'transfer to non ERC721Receiver implementer'
       );
     }
-  });
-
-  it('the platform beneficiary can be a payable contract', async function () {
-    const ChainWallet = (await ethers.getContractFactory(
-      'ChainWallet'
-    )) as ChainWallet__factory;
-    const wallet = await ChainWallet.deploy();
-    splice.setPlatformBeneficiary(wallet.address);
-
-    const nft = await mintTestnetNFT(testNft, _user);
-    const _splice = splice.connect(_user);
-    await mintSplice(_splice, testNft.address, nft, 1);
-    const expected = (0.1 * 0.1).toFixed(2);
-
-    const walletShare = await splice.escrowedBalanceOf(wallet.address);
-    expect(ethers.utils.formatUnits(walletShare, 'ether')).to.be.equal(
-      expected.toString()
-    );
-    await wallet.withdrawShares(splice.address);
-    const walletBalance = await wallet.provider.getBalance(wallet.address);
-    expect(ethers.utils.formatUnits(walletBalance, 'ether')).to.be.equal(
-      expected.toString()
-    );
   });
 
   it('signals EIP-165 support on mandatory interfaces', async function () {

--- a/packages/contracts/test/styles.test.ts
+++ b/packages/contracts/test/styles.test.ts
@@ -44,6 +44,15 @@ describe('Style NFTs', function () {
     priceStrategy = _priceStrategy.connect(_styleMinter);
   });
 
+  it('cannot update the splice contract once connected', async function () {
+    try {
+      await styleNFT.setSplice(splice.address);
+      expect.fail('cannot set splice on an already established contract bond');
+    } catch (e: any) {
+      expect(e.message).to.contain('can only be called once');
+    }
+  });
+
   it('gets an nft on the test collection', async function () {
     const requestor = await _user.getAddress();
     const _nft = testNft.connect(_user);


### PR DESCRIPTION
Partnerships are unique to a style
A style can only have 1 partnership
Partnerships can relate to >=1 partners
A "partner" is actually the address of an origin collection
Partnerships have an expiry date
Partnerships have 1 beneficiary account
The beneficiary gets 50% of platform shares when the partnership is active
An exclusive partnership disallows minting splices on that style
Exclusivity also applies to multi origins: if one origin is not included in the partnership, the mint is rejected.
A non exclusive partnership allows minting on everything but pays out shares when not expired.
When exclusive partnerships have expired, no shares are paid and minting is open to everybody
To fully constrain a style to a certain collection(s), create a partnership for that collection and set the expiration date far into the future.





