### PR TITLE
Asset Context: caches user NFTs

### DIFF
--- a/packages/common/src/indexers/Fallback.ts
+++ b/packages/common/src/indexers/Fallback.ts
@@ -42,26 +42,6 @@ export class Fallback implements NFTIndexer {
   }
 
   public async getAsset(collection: string, tokenId: string): Promise<NFTItem> {
-    let nftItem;
-    try {
-      nftItem = await this.primary.getAsset(collection, tokenId);
-    } catch (e: any) {
-      console.warn('primary indexer missed', e.message);
-      nftItem = await this.fallback.getAsset(collection, tokenId);
-    }
-
-    const resolvedImage = nftItem.metadata
-      ? resolveImage(nftItem.metadata)
-      : undefined;
-    if (!resolvedImage) {
-      console.debug(
-        'no image data from primary indexer, falling back to on chain lookup'
-      );
-      nftItem = await this.fallback.getAsset(collection, tokenId);
-      if (nftItem) {
-        return nftItem;
-      }
-    }
-    return nftItem;
+    return this.fallback.getAsset(collection, tokenId);
   }
 }

--- a/packages/common/src/indexers/Fallback.ts
+++ b/packages/common/src/indexers/Fallback.ts
@@ -19,7 +19,8 @@ export class Fallback implements NFTIndexer {
                 nftportNftItem.contract_address,
                 nftportNftItem.token_id
               )
-              .then((nftItem) => resolve(nftItem?.metadata || null));
+              .then((nftItem) => resolve(nftItem?.metadata || null))
+              .catch((a: any) => resolve(null));
           })
         };
       } else {

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -18,6 +18,7 @@ import { NFTPage } from './components/pages/NFTPage';
 import { RoadmapPage } from './components/pages/Roadmap';
 import { SpliceProvider } from './context/SpliceContext';
 import theme from './theme';
+import { AssetProvider } from './context/AssetContext';
 
 function getLibrary(provider: any) {
   return new providers.Web3Provider(provider);
@@ -34,39 +35,41 @@ function App() {
       <Web3ReactProvider getLibrary={getLibrary}>
         <SpliceProvider>
           <Router>
-            <Header />
+            <AssetProvider>
+              <Header />
 
-            <Switch>
-              <Route path="/nft/:collection/:token_id">
-                <NFTPage />
-              </Route>
-              <Route path="/my-splices">
-                <MySplicesPage />
-              </Route>
+              <Switch>
+                <Route path="/nft/:collection/:token_id">
+                  <NFTPage />
+                </Route>
+                <Route path="/my-splices">
+                  <MySplicesPage />
+                </Route>
 
-              <Route path={['/my-assets/:accountAddress', '/my-assets']}>
-                <MyAssetsPage />
-              </Route>
-              <Route path="/create">
-                <React.Suspense fallback={<></>}>
-                  <CreatePage />
-                </React.Suspense>
-              </Route>
-              <Route path="/style/:style_id">
-                <React.Suspense fallback={<></>}>
-                  <StyleDetailPage />
-                </React.Suspense>
-              </Route>
-              <Route path="/styles">
-                <StylesOverviewPage />
-              </Route>
-              <Route path="/roadmap">
-                <RoadmapPage />
-              </Route>
-              <Route path="/">
-                <AboutPage />
-              </Route>
-            </Switch>
+                <Route path={['/my-assets/:accountAddress', '/my-assets']}>
+                  <MyAssetsPage />
+                </Route>
+                <Route path="/create">
+                  <React.Suspense fallback={<></>}>
+                    <CreatePage />
+                  </React.Suspense>
+                </Route>
+                <Route path="/style/:style_id">
+                  <React.Suspense fallback={<></>}>
+                    <StyleDetailPage />
+                  </React.Suspense>
+                </Route>
+                <Route path="/styles">
+                  <StylesOverviewPage />
+                </Route>
+                <Route path="/roadmap">
+                  <RoadmapPage />
+                </Route>
+                <Route path="/">
+                  <AboutPage />
+                </Route>
+              </Switch>
+            </AssetProvider>
           </Router>
           <Footer />
           <SubFooter />

--- a/packages/dapp/src/components/molecules/MintButton.tsx
+++ b/packages/dapp/src/components/molecules/MintButton.tsx
@@ -12,7 +12,7 @@ import { OnChain } from '@splicenft/common';
 import { useWeb3React } from '@web3-react/core';
 import { BigNumber, Contract, ethers, providers } from 'ethers';
 import React, { useEffect, useState } from 'react';
-import { useSplice } from '../../context/SpliceContext';
+import { useAssets } from '../../context/AssetContext';
 
 const MintingABI = [
   {
@@ -70,7 +70,7 @@ export const MintButton = ({
   onMinted: (collection: string, tokenId: string) => void;
   balance: ethers.BigNumber | undefined;
 }) => {
-  const { indexer } = useSplice();
+  const { indexer } = useAssets();
   const { library, account } = useWeb3React<providers.Web3Provider>();
   const [buzy, setBuzy] = useState<boolean>(false);
 

--- a/packages/dapp/src/components/molecules/NFTCard.tsx
+++ b/packages/dapp/src/components/molecules/NFTCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@splicenft/common';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useAssets } from '../../context/AssetContext';
 import { useSplice } from '../../context/SpliceContext';
 import { truncateAddress } from '../../modules/strings';
 import { FallbackImage } from '../atoms/FallbackImage';
@@ -25,7 +26,9 @@ export const NFTCard = ({ nft }: { nft: NFTItemInTransit }) => {
   const [spliceMetadata, setSpliceMetadata] = useState<SpliceNFT>();
   const [nftMetadata, setNftMetadata] = useState<NFTMetaData>();
   const [nftImageUrl, setNftImageUrl] = useState<string>();
-  const { splice } = useSplice();
+  const [contractName, setContractName] = useState<string>();
+  const { splice, spliceStyles } = useSplice();
+  const { getContractName } = useAssets();
 
   useEffect(() => {
     (async () => {
@@ -40,6 +43,12 @@ export const NFTCard = ({ nft }: { nft: NFTItemInTransit }) => {
       } catch (e: any) {
         console.error('error loading metadata', e);
       }
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      setContractName(await getContractName(nft.contract_address));
     })();
   }, []);
 
@@ -66,15 +75,15 @@ export const NFTCard = ({ nft }: { nft: NFTItemInTransit }) => {
 
   return (
     <SpliceCard flexDirection="column">
-      <AspectRatio ratio={1}>
+      <AspectRatio ratio={1} flex="3">
         {spliceMetadata ? (
-          <Flex position="relative" overflow="hidden">
+          <Flex position="relative">
             <Image src={spliceMetadata.image} fit="cover" boxSize="100%" />
             <Center position="absolute" width="100%" height="100%">
               <Flex
                 rounded="full"
                 border="4px solid white"
-                w="75%"
+                w="70%"
                 overflow="hidden"
                 boxShadow="md"
               >
@@ -86,45 +95,41 @@ export const NFTCard = ({ nft }: { nft: NFTItemInTransit }) => {
           <FallbackImage imgUrl={nftImageUrl} metadata={nftMetadata} />
         )}
       </AspectRatio>
-      <Flex direction="column" flex="1">
+      <Flex direction="column" flex="2">
         <LinkOverlay
           as={Link}
           to={`/nft/${nft.contract_address}/${nft.token_id}`}
           p={4}
           background="white"
-          flex="2"
         >
-          <Heading size="md" flex="1">
+          <Heading size="md">
             {nftMetadata ? nftMetadata.name : nft.name}
           </Heading>
         </LinkOverlay>
 
-        <Flex background="black" direction="row" p={6} flex="2">
-          <Flex
-            direction="row"
-            align="center"
-            justify="space-between"
-            width="100%"
-          >
-            <Flex direction="column">
-              <Text color="gray.200" fontWeight="bold">
-                contract
-              </Text>
-              <Text color="white">{truncateAddress(nft.contract_address)}</Text>
-            </Flex>
+        <Flex
+          background="black"
+          gridGap={1}
+          direction="column"
+          align="flex-start"
+          justify="center"
+          flex="2"
+          p={4}
+        >
+          <Text color="white" fontSize="sm">
+            {contractName || truncateAddress(nft.contract_address)}
+          </Text>
 
-            {provenance && (
-              <Flex direction="column">
-                <Text color="gray.200" fontWeight="bold">
-                  Splice
-                </Text>
-
-                <Text color="white">
-                  {provenance.style_token_id}/{provenance.style_token_token_id}
-                </Text>
-              </Flex>
-            )}
-          </Flex>
+          {provenance && (
+            <Text color="white" fontSize="sm">
+              {
+                spliceStyles
+                  .find((st) => st.tokenId === provenance.style_token_id)
+                  ?.getMetadata().name
+              }{' '}
+              # {provenance.style_token_token_id}
+            </Text>
+          )}
         </Flex>
       </Flex>
     </SpliceCard>

--- a/packages/dapp/src/components/organisms/MetaDataDisplay.tsx
+++ b/packages/dapp/src/components/organisms/MetaDataDisplay.tsx
@@ -60,10 +60,10 @@ export const SpliceMetadataDisplay = ({
   owner?: string;
   spliceMetadata?: SpliceNFT;
   provenance?: TokenProvenance | null;
-  traits: NFTTrait[];
+  traits?: NFTTrait[];
 } & SystemProps) => {
   const { account } = useWeb3React();
-  if (spliceMetadata === undefined && traits.length === 0) return <></>;
+  if (spliceMetadata === undefined && traits?.length === 0) return <></>;
   return (
     <Flex direction="column" {...rest}>
       {spliceMetadata && (
@@ -97,13 +97,13 @@ export const SpliceMetadataDisplay = ({
         </Flex>
       )}
 
-      {traits.length > 0 && (
+      {traits && traits.length > 0 && (
         <>
-          <Heading size="md" mb={3}>
+          <Heading size="md" mb={3} mt={6}>
             Splice attributes
           </Heading>
           <Flex direction="column" gridGap={3}>
-            {traits.map((attr, i) => (
+            {traits?.map((attr, i) => (
               <MetaDataItem
                 fontSize="sm"
                 key={`attr-${attr.trait_type || `unk-${i}`}`}

--- a/packages/dapp/src/components/pages/MyAssets.tsx
+++ b/packages/dapp/src/components/pages/MyAssets.tsx
@@ -2,21 +2,20 @@ import {
   Alert,
   AlertIcon,
   AlertTitle,
+  Button,
   Container,
   Flex,
-  Text,
   Heading,
   Link,
-  Button,
   SimpleGrid,
-  useToast
+  Text
 } from '@chakra-ui/react';
 import { CHAINS, NFTItemInTransit } from '@splicenft/common';
 import { useWeb3React } from '@web3-react/core';
 import { ethers, providers } from 'ethers';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { useSplice } from '../../context/SpliceContext';
+import { useAssets } from '../../context/AssetContext';
 import { MintButton } from '../molecules/MintButton';
 import { NFTCard } from '../molecules/NFTCard';
 
@@ -24,62 +23,25 @@ export const MyAssetsPage = () => {
   const { accountAddress } =
     useParams<{ accountAddress: string | undefined }>();
   const { account, library, chainId } = useWeb3React<providers.Web3Provider>();
-  const { indexer } = useSplice();
+  const {
+    indexer,
+    nfts,
+    nftsLoading,
+    continueLoading,
+    onNFTAdded,
+    setAccountAddress
+  } = useAssets();
   const [balance, setBalance] = useState<ethers.BigNumber>(
     ethers.BigNumber.from(0)
   );
-  const [loading, setLoading] = useState<boolean>(false);
-
-  const [nfts, setNFTs] = useState<NFTItemInTransit[]>([]);
-  const toast = useToast();
-
-  useEffect(() => {
-    if (!account || !indexer) return;
-    (async () => {
-      try {
-        setLoading(true);
-        //todo: either use global state or cache the assets somehow.
-        if (indexer.canBeContinued()) {
-          indexer.reset();
-        }
-        const _nfts = await indexer.getAllAssetsOfOwner(
-          accountAddress || account
-        );
-        setNFTs(_nfts);
-      } catch (e) {
-        toast({
-          status: 'error',
-          title: `couldn't fetch assets ${e}`
-        });
-      }
-      setLoading(false);
-    })();
-  }, [account, indexer]);
 
   useEffect(() => {
     if (!library || !account || !chainId) return;
+    setAccountAddress(accountAddress || account);
     (async () => {
       setBalance(await library.getBalance(account));
     })();
   }, [library, account, chainId]);
-
-  const continueLoading = async () => {
-    const addr = accountAddress || account;
-    if (!addr || !indexer) return;
-    setLoading(true);
-    const _moreNfts = await indexer.getAllAssetsOfOwner(addr);
-    setNFTs([...nfts, ..._moreNfts]);
-
-    setLoading(false);
-  };
-  const onNFTMinted = async (collection: string, tokenId: string) => {
-    if (!library || !indexer) return;
-    const newNft = await indexer.getAsset(collection, tokenId);
-
-    if (newNft) {
-      setNFTs([...nfts, newNft]);
-    }
-  };
 
   const switchToRinkeby = async () => {
     if (library?.provider.request) {
@@ -92,7 +54,7 @@ export const MyAssetsPage = () => {
 
   return (
     <Container maxW="container.xl" minHeight="70vh" pb={12}>
-      {loading && (
+      {nftsLoading && (
         <Alert status="info">
           <AlertTitle>loading</AlertTitle>
         </Alert>
@@ -105,7 +67,7 @@ export const MyAssetsPage = () => {
           </AlertTitle>
         </Alert>
       )}
-      {!loading && chainId && nfts.length === 0 && (
+      {!nftsLoading && chainId && nfts.length === 0 && (
         <Alert status="info" overflow="visible" mt={6}>
           <Flex
             align="center"
@@ -131,7 +93,7 @@ export const MyAssetsPage = () => {
               </AlertTitle>
             </Flex>
             {chainId !== 1 && (
-              <MintButton onMinted={onNFTMinted} balance={balance} />
+              <MintButton onMinted={onNFTAdded} balance={balance} />
             )}
           </Flex>
         </Alert>
@@ -163,7 +125,7 @@ export const MyAssetsPage = () => {
                 align="center"
                 justify="center"
               >
-                <MintButton onMinted={onNFTMinted} balance={balance} />
+                <MintButton onMinted={onNFTAdded} balance={balance} />
               </Flex>
             )}
             {indexer?.canBeContinued() && (

--- a/packages/dapp/src/components/pages/MyAssets.tsx
+++ b/packages/dapp/src/components/pages/MyAssets.tsx
@@ -31,6 +31,7 @@ export const MyAssetsPage = () => {
     onNFTAdded,
     setAccountAddress
   } = useAssets();
+
   const [balance, setBalance] = useState<ethers.BigNumber>(
     ethers.BigNumber.from(0)
   );
@@ -130,7 +131,13 @@ export const MyAssetsPage = () => {
             )}
             {indexer?.canBeContinued() && (
               <Flex width="100%" minH="80" align="center" justify="center">
-                <Button onClick={continueLoading}>load more</Button>
+                <Button
+                  onClick={continueLoading}
+                  disabled={nftsLoading}
+                  isLoading={nftsLoading}
+                >
+                  load more
+                </Button>
               </Flex>
             )}
           </SimpleGrid>

--- a/packages/dapp/src/components/pages/MySplices.tsx
+++ b/packages/dapp/src/components/pages/MySplices.tsx
@@ -23,6 +23,7 @@ import { useWeb3React } from '@web3-react/core';
 import { providers } from 'ethers';
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { useAssets } from '../../context/AssetContext';
 import { useSplice } from '../../context/SpliceContext';
 import {
   UserSplicesData,
@@ -31,11 +32,12 @@ import {
 } from '../../modules/Queries';
 import { FallbackImage } from '../atoms/FallbackImage';
 import { PreviewBase } from '../molecules/PreviewBase';
-
 import { SpliceMetadataDisplay } from '../organisms/MetaDataDisplay';
 
 const SpliceCardDisplay = ({ mySplice }: { mySplice: Transfer.UserSplice }) => {
-  const { indexer, splice } = useSplice();
+  const { splice } = useSplice();
+  const { indexer } = useAssets();
+
   const toast = useToast();
 
   const [origin, setOrigin] = useState<NFTMetaData | null>();
@@ -106,10 +108,7 @@ const SpliceCardDisplay = ({ mySplice }: { mySplice: Transfer.UserSplice }) => {
           {metadata && (
             <>
               <Text>{metadata.description}</Text>
-              <SpliceMetadataDisplay
-                spliceMetadata={metadata}
-                traits={metadata.attributes || []}
-              />
+              <SpliceMetadataDisplay spliceMetadata={metadata} />
             </>
           )}
         </Flex>

--- a/packages/dapp/src/components/pages/NFTPage.tsx
+++ b/packages/dapp/src/components/pages/NFTPage.tsx
@@ -1,4 +1,8 @@
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
@@ -15,12 +19,10 @@ import {
 } from '@chakra-ui/react';
 import { Histogram } from '@splicenft/colors';
 import {
-  dataUriToBlob,
   erc721,
   NFTItem,
   NFTTrait,
   OnChain,
-  resolveImage,
   Splice,
   SpliceNFT,
   Style,
@@ -39,6 +41,7 @@ import React, {
 import { FaCloudDownloadAlt } from 'react-icons/fa';
 import { IoReload } from 'react-icons/io5';
 import { NavLink, useParams } from 'react-router-dom';
+import { useAssets } from '../../context/AssetContext';
 import { useSplice } from '../../context/SpliceContext';
 import { default as getDominantColors, loadColors } from '../../modules/colors';
 import { ArtworkStyleChooser } from '../atoms/ArtworkStyleChooser';
@@ -80,6 +83,11 @@ type State = {
     origin: string | undefined;
   };
   originImage?: HTMLImageElement;
+};
+
+type ContractError = {
+  title: string;
+  description: string;
 };
 
 function reducer(state: State, action: StateAction): State {
@@ -171,9 +179,12 @@ export const NFTPage = () => {
 
   const toast = useToast();
 
-  const { splice, indexer, spliceStyles } = useSplice();
+  const { splice, spliceStyles } = useSplice();
+  const { indexer } = useAssets();
+
   const { library: web3, account, chainId } = useWeb3React();
   const [buzy, setBuzy] = useState<boolean>(false);
+  const [error, setError] = useState<ContractError>();
 
   const [state, dispatch] = useReducer(reducer, {
     origin: {
@@ -211,10 +222,12 @@ export const NFTPage = () => {
           }
         });
       } catch (e: any) {
-        console.error(
-          "couldn't load origin collection information (maybe not an erc721 contract)",
-          e.message
-        );
+        console.error(e.message);
+        setError({
+          title:
+            "couldn't load origin collection information (maybe not an erc721 contract)",
+          description: e.message
+        });
       }
     })();
   }, [web3, account, chainId, splice, indexer]);
@@ -419,7 +432,22 @@ export const NFTPage = () => {
           </Flex>
         </Flex>
       )}
-
+      {error && (
+        <Alert
+          status="error"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+          flexDirection="column"
+          my={6}
+        >
+          <AlertIcon boxSize="40px" mr={0} />
+          <AlertTitle mt={4} mb={1} fontSize="lg">
+            {error.title}
+          </AlertTitle>
+          <AlertDescription maxWidth="md">{error.description}</AlertDescription>
+        </Alert>
+      )}
       <SimpleGrid
         justify="space-between"
         align="flex-start"

--- a/packages/dapp/src/components/pages/StyleDetailPage.tsx
+++ b/packages/dapp/src/components/pages/StyleDetailPage.tsx
@@ -13,19 +13,19 @@ import {
   useToast
 } from '@chakra-ui/react';
 import {
-  Partnership,
-  Style,
-  StyleStats,
-  ReplaceablePaymentSplitter,
+  ipfsGW,
   ISplicePriceStrategy,
-  ipfsGW
+  Partnership,
+  ReplaceablePaymentSplitter,
+  Style,
+  StyleStats
 } from '@splicenft/common';
 import { useWeb3React } from '@web3-react/core';
 import { BigNumber, ethers, providers } from 'ethers';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-
 import { useSplice } from '../../context/SpliceContext';
+
 type PaymentInfo = {
   total: ethers.BigNumber;
   totalReleased: ethers.BigNumber;

--- a/packages/dapp/src/context/AssetContext.tsx
+++ b/packages/dapp/src/context/AssetContext.tsx
@@ -91,10 +91,14 @@ const AssetProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       (async () => {
         setLoading(true);
-        console.log('loading assets...');
-        const _nfts = await indexer.getAllAssetsOfOwner(accountAddress);
-        setNFTs(_nfts);
-        setLoading(false);
+        try {
+          const _nfts = await indexer.getAllAssetsOfOwner(accountAddress);
+          setNFTs(_nfts);
+        } catch (e: any) {
+          console.warn(e.message || e);
+        } finally {
+          setLoading(false);
+        }
       })();
     } catch (e) {
       toast({
@@ -128,7 +132,6 @@ const AssetProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       const contract = erc721(library, address);
       const name = await contract.name();
-      console.debug('[%s] unknown, query resolved to [%s]', address, name);
       setContracts((old) => ({ ...old, [address]: name }));
       return name;
     } catch (e: any) {

--- a/packages/dapp/src/context/AssetContext.tsx
+++ b/packages/dapp/src/context/AssetContext.tsx
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { useToast } from '@chakra-ui/react';
+import {
+  CHAINS,
+  erc721,
+  FallbackIndexer,
+  NFTIndexer,
+  NFTItemInTransit,
+  NFTPort,
+  OnChain
+} from '@splicenft/common';
+import { useWeb3React } from '@web3-react/core';
+import { providers } from 'ethers';
+import React, { useContext, useEffect, useState } from 'react';
+import { knownCollections } from '../modules/chains';
+
+interface IAssetContext {
+  indexer?: NFTIndexer;
+  nfts: NFTItemInTransit[];
+  contracts: Record<string, string>;
+  nftsLoading: boolean;
+  continueLoading: () => void;
+  onNFTAdded: (collection: string, tokenId: string) => Promise<void>;
+  setAccountAddress: (address: string) => void;
+  getContractName: (address: string) => Promise<string | undefined>;
+}
+
+const AssetContext = React.createContext<IAssetContext>({
+  nfts: [],
+  contracts: {},
+  nftsLoading: false,
+  continueLoading: () => {
+    console.log('not ready yet');
+  },
+  onNFTAdded: async (collection: string, tokenId: string) => {},
+  setAccountAddress: (address: string) => {},
+  getContractName: async (address: string) => undefined
+});
+
+const useAssets = () => useContext(AssetContext);
+
+const AssetProvider = ({ children }: { children: React.ReactNode }) => {
+  const { library, chainId, account } = useWeb3React<providers.Web3Provider>();
+  const [indexer, setIndexer] = useState<NFTIndexer>();
+  const toast = useToast();
+  const [loading, setLoading] = useState<boolean>(false);
+  const [nfts, setNFTs] = useState<NFTItemInTransit[]>([]);
+  const [contracts, setContracts] = useState<Record<string, string>>({});
+  const [accountAddress, setAccountAddress] = useState<string | undefined>(
+    account || undefined
+  );
+
+  useEffect(() => {
+    if (!library || !chainId) return;
+
+    const chain = CHAINS[chainId];
+    if (!chain) {
+      setIndexer(undefined);
+      console.error(`chain ${chainId} unsupported`);
+      return;
+    }
+
+    switch (chain) {
+      case 'ethereum':
+        setIndexer(
+          new FallbackIndexer(
+            new NFTPort(chain, process.env.REACT_APP_NFTPORT_AUTH as string),
+            new OnChain(library, knownCollections['ethereum'], {
+              proxyAddress: process.env.REACT_APP_CORS_PROXY,
+              metadataProxy: process.env.REACT_APP_VALIDATOR_BASEURL
+            })
+          )
+        );
+        break;
+
+      default:
+        setIndexer(
+          new OnChain(library, knownCollections[chain], {
+            proxyAddress: process.env.REACT_APP_CORS_PROXY,
+            metadataProxy: process.env.REACT_APP_VALIDATOR_BASEURL
+          })
+        );
+    }
+  }, [library, chainId]);
+
+  useEffect(() => {
+    if (!accountAddress || !indexer) return;
+    if (indexer.canBeContinued()) {
+      indexer.reset();
+    }
+    try {
+      (async () => {
+        setLoading(true);
+        console.log('loading assets...');
+        const _nfts = await indexer.getAllAssetsOfOwner(accountAddress);
+        setNFTs(_nfts);
+        setLoading(false);
+      })();
+    } catch (e) {
+      toast({
+        status: 'error',
+        title: `couldn't fetch assets ${e}`
+      });
+    }
+  }, [accountAddress, indexer]);
+
+  const continueLoading = async () => {
+    if (!accountAddress || !indexer) return;
+    if (!indexer.canBeContinued()) return;
+    setLoading(true);
+    const _moreNfts = await indexer.getAllAssetsOfOwner(accountAddress);
+    setLoading(false);
+    setNFTs([...nfts, ..._moreNfts]);
+  };
+
+  const onNFTAdded = async (collection: string, tokenId: string) => {
+    if (!indexer) return;
+    setLoading(true);
+    const newNft = await indexer.getAsset(collection, tokenId);
+    setLoading(false);
+    setNFTs([...nfts, newNft]);
+  };
+
+  const getContractName = async (address: string) => {
+    const known = contracts[address];
+    if (known) return known as string;
+    if (!library) return undefined;
+    try {
+      const contract = erc721(library, address);
+      const name = await contract.name();
+      console.debug('[%s] unknown, query resolved to [%s]', address, name);
+      setContracts((old) => ({ ...old, [address]: name }));
+      return name;
+    } catch (e: any) {
+      console.warn(e.message || e);
+      return undefined;
+    }
+  };
+
+  return (
+    <AssetContext.Provider
+      value={{
+        indexer,
+        nfts,
+        contracts,
+        continueLoading,
+        onNFTAdded,
+        nftsLoading: loading,
+        setAccountAddress,
+        getContractName
+      }}
+    >
+      {children}
+    </AssetContext.Provider>
+  );
+};
+
+export { AssetProvider, useAssets };

--- a/packages/dapp/src/context/SpliceContext.tsx
+++ b/packages/dapp/src/context/SpliceContext.tsx
@@ -7,10 +7,6 @@ import {
 import {
   ActiveStyle,
   CHAINS,
-  FallbackIndexer,
-  NFTIndexer,
-  NFTPort,
-  OnChain,
   Splice,
   SPLICE_ADDRESSES,
   Style,
@@ -20,11 +16,9 @@ import { useWeb3React } from '@web3-react/core';
 import axios from 'axios';
 import { providers } from 'ethers';
 import React, { useContext, useEffect, useState } from 'react';
-import { knownCollections } from '../modules/chains';
 
 interface ISpliceContext {
   splice?: Splice;
-  indexer?: NFTIndexer;
   spliceStyles: Style[];
 }
 
@@ -36,7 +30,6 @@ type ApolloClientType = ApolloClient<NormalizedCacheObject>;
 const SpliceProvider = ({ children }: { children: React.ReactNode }) => {
   const { library, chainId } = useWeb3React<providers.Web3Provider>();
   const [splice, setSplice] = useState<Splice>();
-  const [indexer, setIndexer] = useState<NFTIndexer>();
   const [spliceStyles, setStyles] = useState<Style[]>([]);
   const [apolloClient, setApolloClient] = useState<ApolloClientType>(
     new ApolloClient({
@@ -52,7 +45,6 @@ const SpliceProvider = ({ children }: { children: React.ReactNode }) => {
     if (!chain) {
       setSplice(undefined);
       setStyles([]);
-      setIndexer(undefined);
       console.error(`chain ${chainId} unsupported`);
       return;
     }
@@ -88,28 +80,6 @@ const SpliceProvider = ({ children }: { children: React.ReactNode }) => {
         setSplice(undefined);
       }
     }
-
-    switch (chain) {
-      case 'ethereum':
-        setIndexer(
-          new FallbackIndexer(
-            new NFTPort(chain, process.env.REACT_APP_NFTPORT_AUTH as string),
-            new OnChain(library, knownCollections['ethereum'], {
-              proxyAddress: process.env.REACT_APP_CORS_PROXY,
-              metadataProxy: process.env.REACT_APP_VALIDATOR_BASEURL
-            })
-          )
-        );
-        break;
-
-      default:
-        setIndexer(
-          new OnChain(library, knownCollections[chain], {
-            proxyAddress: process.env.REACT_APP_CORS_PROXY,
-            metadataProxy: process.env.REACT_APP_VALIDATOR_BASEURL
-          })
-        );
-    }
   }, [library, chainId]);
 
   useEffect(() => {
@@ -144,7 +114,7 @@ const SpliceProvider = ({ children }: { children: React.ReactNode }) => {
   }, [chainId, splice]);
 
   return (
-    <SpliceContext.Provider value={{ splice, indexer, spliceStyles }}>
+    <SpliceContext.Provider value={{ splice, spliceStyles }}>
       <ApolloProvider client={apolloClient}>{children}</ApolloProvider>
     </SpliceContext.Provider>
   );

--- a/packages/dapp/src/theme/Alert.ts
+++ b/packages/dapp/src/theme/Alert.ts
@@ -2,14 +2,14 @@ const Alert = {
   parts: ['container', 'title'],
   baseStyle: {
     container: {
-      rounded: 'full',
+      rounded: 'lg',
       px: '2em',
       py: '1.5em',
       boxShadow: 'md',
       flexDirection: 'row'
     },
     title: {
-      fontWeight: 'regular',
+      fontWeight: 'bold',
       fontSize: 'lg'
     }
   },


### PR DESCRIPTION
moves all origin collection / indexing code to its own context that keeps NFTs for the page duration
displays contract / style names on MyAssets page
reacts on account changes
fallback.getAsset always loads from chain to avoid misses on NFTPort